### PR TITLE
Use audit policy and splunk secret from resource references.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # gardener-extension-audit
 
-Provides a Gardener extension for sending audit traces to a backend and forwarding them into the shoot cluster.
+Provides a Gardener extension for sending managing kube-apiserver audit logs for a shoot cluster.
+
+The extension spins up a fluentbit-based audit sink in the seed's shoot namespace prior to starting the shoot's API server. Therefore, it is required to run this extension with the reconcile lifecycle policy `BeforeKubeAPIServer`. This sink has the ability to buffer audit logs to a persistent volume and send them to the supported backends.
+
+## Specifying An Audit Policy
+
+A custom audit policy can be natively configured by Gardener in the shoot spec's API server configuration under `.spec.kubernetes.kubeAPIServer.auditConfig.auditPolicy.configMapRef`.
 
 ## Supported Backends
 
+- Log (just logs to the container, only for developers)
+- Cluster Forwarding (forwards audit logs into a pod in the shoot cluster, should not be used for production purposes)
 - Splunk

--- a/README.md
+++ b/README.md
@@ -1,15 +1,26 @@
 # gardener-extension-audit
 
-Provides a Gardener extension for sending managing kube-apiserver audit logs for a shoot cluster.
+Provides a Gardener extension for managing kube-apiserver audit logs for a shoot cluster.
 
-The extension spins up a fluentbit-based audit sink in the seed's shoot namespace prior to starting the shoot's API server. Therefore, it is required to run this extension with the reconcile lifecycle policy `BeforeKubeAPIServer`. This sink has the ability to buffer audit logs to a persistent volume and send them to the supported backends.
+The extension spins up a fluentbit-based audit sink in the seed's shoot namespace prior to starting the shoot's API server. Therefore, it is required to run this extension with the reconcile lifecycle policy `BeforeKubeAPIServer`.
+
+This sink has the ability to buffer audit logs to a persistent volume and send them to the supported backends.
 
 ## Specifying An Audit Policy
 
-A custom audit policy can be natively configured by Gardener in the shoot spec's API server configuration under `.spec.kubernetes.kubeAPIServer.auditConfig.auditPolicy.configMapRef`.
+A custom audit policy can be natively configured by Gardener in the shoot spec's API server configuration under `.spec.kubernetes.kubeAPIServer.auditConfig.auditPolicy.configMapRef.name`.
 
 ## Supported Backends
 
-- Log (just logs to the container, only for developers)
+- Log (just logs to the container, only for devel-purposes)
 - Cluster Forwarding (forwards audit logs into a pod in the shoot cluster, should not be used for production purposes)
 - Splunk
+
+## Development
+
+This extension can be developed in the gardener-local devel environment.
+
+1. Start up the local devel environment
+1. The extension's docker image can be pushed into Kind using `make push-to-gardener-local`
+1. Install the extension `kubectl apply -k example/`
+1. Parametrize the `example/shoot.yaml` and apply with `kubectl -f example/shoot.yaml`

--- a/example/10-custom-audit-policy.yaml
+++ b/example/10-custom-audit-policy.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: custom-audit-policy
+  namespace: garden-local
+stringData:
+  policy: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    omitStages:
+      - "RequestReceived"
+    rules:
+      - level: RequestResponse
+        resources:
+        - group: ""
+          resources: ["pods"]
+      - level: Metadata
+        resources:
+        - group: ""
+          resources: ["pods/log", "pods/status"]

--- a/example/10-custom-audit-policy.yaml
+++ b/example/10-custom-audit-policy.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: custom-audit-policy
   namespace: garden-local
-stringData:
+data:
   policy: |
     apiVersion: audit.k8s.io/v1
     kind: Policy

--- a/example/10-splunk-secret.yaml
+++ b/example/10-splunk-secret.yaml
@@ -5,8 +5,8 @@ metadata:
   name: splunk-secret
   namespace: garden-local
 stringData:
-  hecToken: <hec token>
-  caFile: |
+  token: <hec token>
+  ca: |
     -----BEGIN CERTIFICATE-----
     <cert>
     -----END CERTIFICATE-----

--- a/example/10-splunk-secret.yaml
+++ b/example/10-splunk-secret.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: splunk-secret
+  namespace: garden-local
+stringData:
+  hecToken: <hec token>
+  caFile: |
+    -----BEGIN CERTIFICATE-----
+    <cert>
+    -----END CERTIFICATE-----
+    -----BEGIN CERTIFICATE-----
+    <cert>
+    -----END CERTIFICATE-----

--- a/example/shoot.yaml
+++ b/example/shoot.yaml
@@ -35,6 +35,7 @@ spec:
   # resources:
   #   - name: splunk-secret
   #     resourceRef:
+  #       apiVersion: v1
   #       kind: Secret
   #       name: splunk-secret
   networking:

--- a/example/shoot.yaml
+++ b/example/shoot.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: core.gardener.cloud/v1beta1
 kind: Shoot
 metadata:
@@ -17,41 +18,25 @@ spec:
       apiVersion: audit.metal.extensions.gardener.cloud/v1alpha1
       kind: AuditConfig
       webhookMode: blocking
+      # persistence:
+      #   size: 10Gi
       backends:
         log:
           enabled: true
-        clusterForwarding:
-          enabled: false
-        splunk:
-          enabled: true
-          index: <splunk index>
-          host: splunk-endpoint.example.com
-          port: "443"
-          hecToken: <hec token>
-          caFile: |
-            -----BEGIN CERTIFICATE-----
-            <cert>
-            -----END CERTIFICATE-----
-            -----BEGIN CERTIFICATE-----
-            <cert>
-            -----END CERTIFICATE-----
-          tls: true
-      # persistence:
-      #   size: 10Gi
-      # auditPolicy: |
-      #   apiVersion: audit.k8s.io/v1
-      #   kind: Policy
-      #   omitStages:
-      #     - "RequestReceived"
-      #   rules:
-      #     - level: RequestResponse
-      #       resources:
-      #       - group: ""
-      #         resources: ["pods"]
-      #     - level: Metadata
-      #       resources:
-      #       - group: ""
-      #         resources: ["pods/log", "pods/status"]
+        # clusterForwarding:
+        #   enabled: true
+        # splunk:
+        #   enabled: true
+        #   index: <splunk index>
+        #   host: splunk-endpoint.example.com
+        #   port: "443"
+        #   secretResourceName: splunk-secret
+        #   tls: true
+  # resources:
+  #   - name: splunk-secret
+  #     resourceRef:
+  #       kind: Secret
+  #       name: splunk-secret
   networking:
     type: calico
     providerConfig:
@@ -78,3 +63,7 @@ spec:
       registryBurst: 20
       protectKernelDefaults: true
       streamingConnectionIdleTimeout: 5m
+    # kubeAPIServer:
+    #   auditConfig:
+    #     auditPolicy:
+    #       configMapRef: custom-audit-policy

--- a/example/shoot.yaml
+++ b/example/shoot.yaml
@@ -66,4 +66,5 @@ spec:
     # kubeAPIServer:
     #   auditConfig:
     #     auditPolicy:
-    #       configMapRef: custom-audit-policy
+    #       configMapRef:
+    #         name: custom-audit-policy

--- a/pkg/apis/audit/types.go
+++ b/pkg/apis/audit/types.go
@@ -27,10 +27,6 @@ type AuditConfig struct {
 	// WebhookMode allows to select which auditing mode - batching or blocking - should be used.
 	WebhookMode AuditWebhookMode
 
-	// AuditPolicy contains the audit policy to be used for the cluster, as unencoded string.
-	// If none is supplied, a default auditpolicy is used.
-	AuditPolicy *string
-
 	// Backends contains the settings for the various backends.
 	Backends *AuditBackends
 }
@@ -85,10 +81,13 @@ type AuditBackendSplunk struct {
 	// Port ist the port on which the HEC endpoint is listening.
 	Port string
 
-	// Token is the splunk HEC token necessary to send log data to this Host/Index.
-	Token string
-	// CaFile contains, in an unencoded string, the CA (bundle) of the CA that signed the HEC endpoint's server certificate.
-	CaFile string
+	// SecretResourceName is a reference under Shoot.spec.resources to the secret used to authenticate against the splunk backend.
+	//
+	// The referenced secret may contain the following keys:
+	//
+	// - token: Required, hec token to authenticate against this host/index
+	// - ca: Optional, the CA (bundle) that signed the HEC endpoint's server certificate as an unencoded string.
+	SecretResourceName string
 
 	// TlsEnabled determines whether TLS should be used to communicate to the HEC endpoint.
 	TlsEnabled bool

--- a/pkg/apis/audit/v1alpha1/types.go
+++ b/pkg/apis/audit/v1alpha1/types.go
@@ -13,6 +13,9 @@ const (
 	AuditWebhookModeBatch          AuditWebhookMode = "batch"
 	AuditWebhookModeBlocking       AuditWebhookMode = "blocking"
 	AuditWebhookModeBlockingStrict AuditWebhookMode = "blocking-strict"
+
+	SplunkSecretTokenKey  = "token"
+	SplunkSecretCaFileKey = "ca"
 )
 
 type (
@@ -31,10 +34,6 @@ type AuditConfig struct {
 
 	// WebhookMode allows to select which auditing mode - batching or blocking - should be used.
 	WebhookMode AuditWebhookMode `json:"webhookMode,omitempty"`
-
-	// AuditPolicy contains the audit policy to be used for the cluster, as unencoded string.
-	// If none is supplied, a default auditpolicy is used.
-	AuditPolicy *string `json:"auditPolicy,omitempty"`
 
 	// Backends contains the settings for the various backends.
 	Backends *AuditBackends `json:"backends,omitempty"`
@@ -96,11 +95,13 @@ type AuditBackendSplunk struct {
 	// Port ist the port on which the HEC endpoint is listening.
 	Port string `json:"port"`
 
-	// Token is the splunk HEC token necessary to send log data to this Host/Index.
-	Token string `json:"hecToken"`
-
-	// CaFile contains, in an unencoded string, the CA (bundle) of the CA that signed the HEC endpoint's server certificate.
-	CaFile string `json:"caFile"`
+	// SecretResourceName is a reference under Shoot.spec.resources to the secret used to authenticate against the splunk backend.
+	//
+	// The referenced secret may contain the following keys:
+	//
+	// - token: Required, hec token to authenticate against this host/index
+	// - ca: Optional, the CA (bundle) that signed the HEC endpoint's server certificate as an unencoded string.
+	SecretResourceName string `json:"secretResourceName"`
 
 	// TlsEnabled determines whether TLS should be used to communicate to the HEC endpoint.
 	TlsEnabled bool `json:"tls"`

--- a/pkg/apis/audit/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/audit/v1alpha1/zz_generated.conversion.go
@@ -89,6 +89,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 
 func autoConvert_v1alpha1_AuditBackendClusterForwarding_To_audit_AuditBackendClusterForwarding(in *AuditBackendClusterForwarding, out *audit.AuditBackendClusterForwarding, s conversion.Scope) error {
 	out.Enabled = in.Enabled
+	out.FilesystemBufferSize = in.FilesystemBufferSize
 	return nil
 }
 
@@ -99,6 +100,7 @@ func Convert_v1alpha1_AuditBackendClusterForwarding_To_audit_AuditBackendCluster
 
 func autoConvert_audit_AuditBackendClusterForwarding_To_v1alpha1_AuditBackendClusterForwarding(in *audit.AuditBackendClusterForwarding, out *AuditBackendClusterForwarding, s conversion.Scope) error {
 	out.Enabled = in.Enabled
+	out.FilesystemBufferSize = in.FilesystemBufferSize
 	return nil
 }
 
@@ -129,11 +131,11 @@ func Convert_audit_AuditBackendLog_To_v1alpha1_AuditBackendLog(in *audit.AuditBa
 
 func autoConvert_v1alpha1_AuditBackendSplunk_To_audit_AuditBackendSplunk(in *AuditBackendSplunk, out *audit.AuditBackendSplunk, s conversion.Scope) error {
 	out.Enabled = in.Enabled
+	out.FilesystemBufferSize = in.FilesystemBufferSize
 	out.Index = in.Index
 	out.Host = in.Host
 	out.Port = in.Port
-	out.Token = in.Token
-	out.CaFile = in.CaFile
+	out.SecretResourceName = in.SecretResourceName
 	out.TlsEnabled = in.TlsEnabled
 	return nil
 }
@@ -145,11 +147,11 @@ func Convert_v1alpha1_AuditBackendSplunk_To_audit_AuditBackendSplunk(in *AuditBa
 
 func autoConvert_audit_AuditBackendSplunk_To_v1alpha1_AuditBackendSplunk(in *audit.AuditBackendSplunk, out *AuditBackendSplunk, s conversion.Scope) error {
 	out.Enabled = in.Enabled
+	out.FilesystemBufferSize = in.FilesystemBufferSize
 	out.Index = in.Index
 	out.Host = in.Host
 	out.Port = in.Port
-	out.Token = in.Token
-	out.CaFile = in.CaFile
+	out.SecretResourceName = in.SecretResourceName
 	out.TlsEnabled = in.TlsEnabled
 	return nil
 }
@@ -186,7 +188,6 @@ func Convert_audit_AuditBackends_To_v1alpha1_AuditBackends(in *audit.AuditBacken
 func autoConvert_v1alpha1_AuditConfig_To_audit_AuditConfig(in *AuditConfig, out *audit.AuditConfig, s conversion.Scope) error {
 	out.Persistence = (*audit.AuditPersistence)(unsafe.Pointer(in.Persistence))
 	out.WebhookMode = audit.AuditWebhookMode(in.WebhookMode)
-	out.AuditPolicy = (*string)(unsafe.Pointer(in.AuditPolicy))
 	out.Backends = (*audit.AuditBackends)(unsafe.Pointer(in.Backends))
 	return nil
 }
@@ -199,7 +200,6 @@ func Convert_v1alpha1_AuditConfig_To_audit_AuditConfig(in *AuditConfig, out *aud
 func autoConvert_audit_AuditConfig_To_v1alpha1_AuditConfig(in *audit.AuditConfig, out *AuditConfig, s conversion.Scope) error {
 	out.Persistence = (*AuditPersistence)(unsafe.Pointer(in.Persistence))
 	out.WebhookMode = AuditWebhookMode(in.WebhookMode)
-	out.AuditPolicy = (*string)(unsafe.Pointer(in.AuditPolicy))
 	out.Backends = (*AuditBackends)(unsafe.Pointer(in.Backends))
 	return nil
 }

--- a/pkg/apis/audit/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/audit/v1alpha1/zz_generated.deepcopy.go
@@ -101,11 +101,6 @@ func (in *AuditConfig) DeepCopyInto(out *AuditConfig) {
 		*out = new(AuditPersistence)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.AuditPolicy != nil {
-		in, out := &in.AuditPolicy, &out.AuditPolicy
-		*out = new(string)
-		**out = **in
-	}
 	if in.Backends != nil {
 		in, out := &in.Backends, &out.Backends
 		*out = new(AuditBackends)

--- a/pkg/apis/audit/zz_generated.deepcopy.go
+++ b/pkg/apis/audit/zz_generated.deepcopy.go
@@ -101,11 +101,6 @@ func (in *AuditConfig) DeepCopyInto(out *AuditConfig) {
 		*out = new(AuditPersistence)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.AuditPolicy != nil {
-		in, out := &in.AuditPolicy, &out.AuditPolicy
-		*out = new(string)
-		**out = **in
-	}
 	if in.Backends != nil {
 		in, out := &in.Backends, &out.Backends
 		*out = new(AuditBackends)

--- a/pkg/controller/actuator.go
+++ b/pkg/controller/actuator.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	extensionssecretsmanager "github.com/gardener/gardener/extensions/pkg/util/secret/manager"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/extensions"
@@ -42,185 +43,7 @@ import (
 )
 
 const (
-	defaultAuditPolicy = `
-apiVersion: audit.k8s.io/v1
-kind: Policy
-rules:
-  # The following requests were manually identified as high-volume and low-risk,
-  # so drop them.
-  - level: None
-    resources:
-      - group: ""
-        resources:
-          - endpoints
-          - services
-          - services/status
-    users:
-      - 'system:kube-proxy'
-    verbs:
-      - watch
-  - level: None
-    resources:
-      - group: ""
-        resources:
-          - nodes
-          - nodes/status
-    userGroups:
-      - 'system:nodes'
-    verbs:
-      - get
-  - level: None
-    namespaces:
-      - kube-system
-    resources:
-      - group: ""
-        resources:
-          - endpoints
-    users:
-      - 'system:kube-controller-manager'
-      - 'system:kube-scheduler'
-      - 'system:serviceaccount:kube-system:endpoint-controller'
-    verbs:
-      - get
-      - update
-  - level: None
-    resources:
-      - group: ""
-        resources:
-          - namespaces
-          - namespaces/status
-          - namespaces/finalize
-    users:
-      - 'system:apiserver'
-    verbs:
-      - get
-  # Don't log HPA fetching metrics.
-  - level: None
-    resources:
-      - group: metrics.k8s.io
-    users:
-      - 'system:kube-controller-manager'
-    verbs:
-      - get
-      - list
-  # Don't log these read-only URLs.
-  - level: None
-    nonResourceURLs:
-      - '/healthz*'
-      - /version
-      - '/swagger*'
-  # Don't log events requests.
-  - level: None
-    resources:
-      - group: ""
-        resources:
-          - events
-  # node and pod status calls from nodes are high-volume and can be large, don't log responses for expected updates from nodes
-  - level: Request
-    omitStages:
-      - RequestReceived
-    resources:
-      - group: ""
-        resources:
-          - nodes/status
-          - pods/status
-    users:
-      - kubelet
-      - 'system:node-problem-detector'
-      - 'system:serviceaccount:kube-system:node-problem-detector'
-    verbs:
-      - update
-      - patch
-  - level: Request
-    omitStages:
-      - RequestReceived
-    resources:
-      - group: ""
-        resources:
-          - nodes/status
-          - pods/status
-    userGroups:
-      - 'system:nodes'
-    verbs:
-      - update
-      - patch
-  # deletecollection calls can be large, don't log responses for expected namespace deletions
-  - level: Request
-    omitStages:
-      - RequestReceived
-    users:
-      - 'system:serviceaccount:kube-system:namespace-controller'
-    verbs:
-      - deletecollection
-  # Secrets, ConfigMaps, and TokenReviews can contain sensitive & binary data,
-  # so only log at the Metadata level.
-  - level: Metadata
-    omitStages:
-      - RequestReceived
-    resources:
-      - group: ""
-        resources:
-          - secrets
-          - configmaps
-      - group: authentication.k8s.io
-        resources:
-          - tokenreviews
-  # Get repsonses can be large; skip them.
-  - level: Request
-    omitStages:
-      - RequestReceived
-    resources:
-      - group: ""
-      - group: admissionregistration.k8s.io
-      - group: apiextensions.k8s.io
-      - group: apiregistration.k8s.io
-      - group: apps
-      - group: authentication.k8s.io
-      - group: authorization.k8s.io
-      - group: autoscaling
-      - group: batch
-      - group: certificates.k8s.io
-      - group: extensions
-      - group: metrics.k8s.io
-      - group: networking.k8s.io
-      - group: policy
-      - group: rbac.authorization.k8s.io
-      - group: scheduling.k8s.io
-      - group: settings.k8s.io
-      - group: storage.k8s.io
-    verbs:
-      - get
-      - list
-      - watch
-  # Default level for known APIs
-  - level: RequestResponse
-    omitStages:
-      - RequestReceived
-    resources:
-      - group: ""
-      - group: admissionregistration.k8s.io
-      - group: apiextensions.k8s.io
-      - group: apiregistration.k8s.io
-      - group: apps
-      - group: authentication.k8s.io
-      - group: authorization.k8s.io
-      - group: autoscaling
-      - group: batch
-      - group: certificates.k8s.io
-      - group: extensions
-      - group: metrics.k8s.io
-      - group: networking.k8s.io
-      - group: policy
-      - group: rbac.authorization.k8s.io
-      - group: scheduling.k8s.io
-      - group: settings.k8s.io
-      - group: storage.k8s.io
-  # Default level for all other requests.
-  - level: Metadata
-    omitStages:
-      - RequestReceived
-`
-	defaultPersitenceSize       = "1Gi"
+	defaultPersistenceSize      = "1Gi"
 	defaultForwardingBufferSize = "900M"
 	defaultSplunkBufferSize     = "900M"
 )
@@ -264,11 +87,7 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ex *extension
 	}
 
 	if auditConfig.Persistence.Size == nil {
-		auditConfig.Persistence.Size = pointer.Pointer(defaultPersitenceSize)
-	}
-
-	if auditConfig.AuditPolicy == nil {
-		auditConfig.AuditPolicy = pointer.Pointer(defaultAuditPolicy)
+		auditConfig.Persistence.Size = pointer.Pointer(defaultPersistenceSize)
 	}
 
 	if auditConfig.Backends == nil {
@@ -286,7 +105,25 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ex *extension
 		return err
 	}
 
-	if err := a.createResources(ctx, log, auditConfig, cluster, namespace); err != nil {
+	splunkSecret := &corev1.Secret{}
+	if pointer.SafeDeref(auditConfig.Backends.Splunk).Enabled {
+		secretRef := helper.GetResourceByName(cluster.Shoot.Spec.Resources, auditConfig.Backends.Splunk.SecretResourceName)
+		if secretRef == nil {
+			return fmt.Errorf("splunk secret resource with name %q not found in shoot resources", auditConfig.Backends.Splunk.SecretResourceName)
+		}
+
+		err = controller.GetObjectByReference(ctx, a.client, &secretRef.ResourceRef, namespace, splunkSecret)
+		if err != nil {
+			return fmt.Errorf("unable to get referenced splunk secret: %w", err)
+		}
+
+		_, ok := splunkSecret.Data[v1alpha1.SplunkSecretTokenKey]
+		if !ok {
+			return fmt.Errorf("referenced splunk secret does not contain contents under key %q", v1alpha1.SplunkSecretTokenKey)
+		}
+	}
+
+	if err := a.createResources(ctx, log, auditConfig, cluster, splunkSecret, namespace); err != nil {
 		return err
 	}
 
@@ -308,7 +145,7 @@ func (a *actuator) Migrate(ctx context.Context, log logr.Logger, ex *extensionsv
 	return nil
 }
 
-func (a *actuator) createResources(ctx context.Context, log logr.Logger, auditConfig *v1alpha1.AuditConfig, cluster *extensions.Cluster, namespace string) error {
+func (a *actuator) createResources(ctx context.Context, log logr.Logger, auditConfig *v1alpha1.AuditConfig, cluster *extensions.Cluster, splunkSecret *corev1.Secret, namespace string) error {
 	const (
 		auditForwaderAccessSecretName = gutil.SecretNamePrefixShootAccess + "audit-cluster-forwarding-vpn-gateway"
 	)
@@ -323,12 +160,12 @@ func (a *actuator) createResources(ctx context.Context, log logr.Logger, auditCo
 		return err
 	}
 
-	shootObjects, err := shootObjects(secrets)
+	shootObjects, err := shootObjects(auditConfig, secrets)
 	if err != nil {
 		return err
 	}
 
-	seedObjects, err := seedObjects(auditConfig, secrets, cluster, shootAccessSecret.Secret.Name, namespace)
+	seedObjects, err := seedObjects(auditConfig, secrets, cluster, splunkSecret, shootAccessSecret.Secret.Name, namespace)
 	if err != nil {
 		return err
 	}
@@ -430,7 +267,7 @@ func (a *actuator) generateSecrets(ctx context.Context, log logr.Logger, cluster
 	return secrets, nil
 }
 
-func seedObjects(auditConfig *v1alpha1.AuditConfig, secrets map[string]*corev1.Secret, cluster *extensions.Cluster, shootAccessSecretName, namespace string) ([]client.Object, error) {
+func seedObjects(auditConfig *v1alpha1.AuditConfig, secrets map[string]*corev1.Secret, cluster *extensions.Cluster, splunkSecretFromResources *corev1.Secret, shootAccessSecretName, namespace string) ([]client.Object, error) {
 	fluentBitImage, err := imagevector.ImageVector().FindImage("fluent-bit")
 	if err != nil {
 		return nil, fmt.Errorf("failed to find fluent-bit image: %w", err)
@@ -472,16 +309,6 @@ func seedObjects(auditConfig *v1alpha1.AuditConfig, secrets map[string]*corev1.S
 						"*.backend.conf",
 					},
 				}.Generate(),
-			},
-		}
-
-		auditPolicyConfigMap = &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "audit-policy",
-				Namespace: namespace,
-			},
-			Data: map[string]string{
-				"audit-policy.yaml": *auditConfig.AuditPolicy,
 			},
 		}
 
@@ -584,7 +411,6 @@ func seedObjects(auditConfig *v1alpha1.AuditConfig, secrets map[string]*corev1.S
 	objects := []client.Object{
 		auditwebhookStatefulSet,
 		auditWebhookConfigSecret,
-		auditPolicyConfigMap,
 		fluentbitConfigMap,
 		&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -812,7 +638,7 @@ func seedObjects(auditConfig *v1alpha1.AuditConfig, secrets map[string]*corev1.S
 			"splunk_token":             "${SPLUNK_HEC_TOKEN}",
 			"retry_limit":              "False",
 			"splunk_send_raw":          "Off",
-			"event_source":             "statefulset:audit-webhook-backend",
+			"event_source":             "statefulset:" + auditwebhookStatefulSet.Name,
 			"event_sourcetype":         "kube:apiserver:auditlog",
 			"event_index":              auditConfig.Backends.Splunk.Index,
 			"event_host":               cluster.ObjectMeta.Name,
@@ -826,9 +652,6 @@ func seedObjects(auditConfig *v1alpha1.AuditConfig, secrets map[string]*corev1.S
 			splunkConfig["tls"] = "on"
 			splunkConfig["tls.verify"] = "on"
 		}
-		if auditConfig.Backends.Splunk.CaFile != "" {
-			splunkConfig["tls.ca_file "] = "/backends/splunk/certs/ca.crt"
-		}
 
 		fluentbitConfigMap.Data["splunk.backend.conf"] = fluentbitconfig.Config{
 			Output: []fluentbitconfig.Output{splunkConfig},
@@ -839,13 +662,28 @@ func seedObjects(auditConfig *v1alpha1.AuditConfig, secrets map[string]*corev1.S
 				Name:      "audit-splunk-secret",
 				Namespace: namespace,
 			},
-			StringData: map[string]string{
-				"splunk_hec_token": auditConfig.Backends.Splunk.Token,
+			Data: map[string][]byte{
+				"splunk_hec_token": splunkSecretFromResources.Data[v1alpha1.SplunkSecretTokenKey],
 			},
 		}
 
-		if auditConfig.Backends.Splunk.TlsEnabled {
-			splunkSecret.StringData["ca.crt"] = auditConfig.Backends.Splunk.CaFile
+		auditwebhookStatefulSet.Spec.Template.Spec.Containers[0].Env = append(auditwebhookStatefulSet.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+			Name: "SPLUNK_HEC_TOKEN",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: splunkSecret.ObjectMeta.Name,
+					},
+					Key: "splunk_hec_token",
+				},
+			},
+		})
+
+		caFile := splunkSecret.Data[v1alpha1.SplunkSecretCaFileKey]
+		if len(caFile) > 0 {
+			splunkConfig["tls.ca_file "] = "/backends/splunk/certs/ca.crt"
+
+			splunkSecret.Data["ca.crt"] = caFile
 
 			auditwebhookStatefulSet.Spec.Template.Spec.Volumes = append(auditwebhookStatefulSet.Spec.Template.Spec.Volumes, corev1.Volume{
 				Name: "splunk-secret",
@@ -865,21 +703,10 @@ func seedObjects(auditConfig *v1alpha1.AuditConfig, secrets map[string]*corev1.S
 				Name:      "splunk-secret",
 				MountPath: "/backends/splunk/certs",
 			})
-			auditwebhookStatefulSet.Spec.Template.Spec.Containers[0].Env = append(auditwebhookStatefulSet.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
-				Name: "SPLUNK_HEC_TOKEN",
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: splunkSecret.ObjectMeta.Name,
-						},
-						Key: "splunk_hec_token",
-					},
-				},
-			})
-
-			auditwebhookStatefulSet.Spec.Template.ObjectMeta.Annotations["checksum/splunk-secret"] = utils.ComputeSecretChecksum(splunkSecret.Data)
-
 		}
+
+		auditwebhookStatefulSet.Spec.Template.ObjectMeta.Annotations["checksum/splunk-secret"] = utils.ComputeSecretChecksum(splunkSecret.Data)
+
 		objects = append(objects, splunkSecret)
 	}
 
@@ -930,7 +757,11 @@ func webhookKubeconfig(namespace string) ([]byte, error) {
 	return kubeconfig, nil
 }
 
-func shootObjects(secrets map[string]*corev1.Secret) ([]client.Object, error) {
+func shootObjects(auditConfig *v1alpha1.AuditConfig, secrets map[string]*corev1.Secret) ([]client.Object, error) {
+	if !pointer.SafeDeref(auditConfig.Backends.ClusterForwarding).Enabled {
+		return nil, nil
+	}
+
 	audittailerImage, err := imagevector.ImageVector().FindImage("audittailer")
 	if err != nil {
 		return nil, fmt.Errorf("failed to find audittailer image: %w", err)

--- a/pkg/controller/actuator.go
+++ b/pkg/controller/actuator.go
@@ -679,7 +679,7 @@ func seedObjects(auditConfig *v1alpha1.AuditConfig, secrets map[string]*corev1.S
 			},
 		})
 
-		caFile := splunkSecret.Data[v1alpha1.SplunkSecretCaFileKey]
+		caFile := splunkSecretFromResources.Data[v1alpha1.SplunkSecretCaFileKey]
 		if len(caFile) > 0 {
 			splunkConfig["tls.ca_file "] = "/backends/splunk/certs/ca.crt"
 

--- a/pkg/webhook/kapiserver/ensurer.go
+++ b/pkg/webhook/kapiserver/ensurer.go
@@ -99,11 +99,6 @@ func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, gctx gconte
 
 func ensureVolumeMounts(c *corev1.Container) {
 	c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, corev1.VolumeMount{
-		Name:      "audit-policy",
-		ReadOnly:  true,
-		MountPath: "/etc/audit-webhook/policy",
-	})
-	c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, corev1.VolumeMount{
 		Name:      "audit-webhook-config",
 		ReadOnly:  true,
 		MountPath: "/etc/audit-webhook/config",
@@ -111,16 +106,6 @@ func ensureVolumeMounts(c *corev1.Container) {
 }
 
 func ensureVolumes(ps *corev1.PodSpec) {
-	ps.Volumes = extensionswebhook.EnsureVolumeWithName(ps.Volumes, corev1.Volume{
-		Name: "audit-policy",
-		VolumeSource: corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: "audit-policy",
-				},
-			},
-		},
-	})
 	ps.Volumes = extensionswebhook.EnsureVolumeWithName(ps.Volumes, corev1.Volume{
 		Name: "audit-webhook-config",
 		VolumeSource: corev1.VolumeSource{
@@ -132,7 +117,6 @@ func ensureVolumes(ps *corev1.PodSpec) {
 }
 
 func ensureKubeAPIServerCommandLineArgs(c *corev1.Container, webhookMode v1alpha1.AuditWebhookMode) {
-	c.Command = extensionswebhook.EnsureStringWithPrefix(c.Command, "--audit-policy-file=", "/etc/audit-webhook/policy/audit-policy.yaml")
 	c.Command = extensionswebhook.EnsureStringWithPrefix(c.Command, "--audit-webhook-config-file=", "/etc/audit-webhook/config/audit-webhook-config.yaml")
 	c.Command = extensionswebhook.EnsureStringWithPrefix(c.Command, "--audit-webhook-mode=", string(webhookMode))
 }


### PR DESCRIPTION
- The audit policy can already be defined in the shoot spec, no need to have an own field for this
- Use the resource references in the shoot spec to provide the splunk secret, this prevents any direct secrets exposed in the shoot resource
- Do not deploy audittailer to shoot if cluster forwarding is not enabled
- Update README