### PR TITLE
Point out deletion lifecycle policy has to be `BeforeKubeAPIServer` now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Provides a Gardener extension for managing kube-apiserver audit logs for a shoot cluster.
 
-The extension spins up a fluentbit-based audit sink in the seed's shoot namespace prior to starting the shoot's API server. Therefore, it is required to run this extension with the reconcile lifecycle policy `BeforeKubeAPIServer`.
+The extension spins up a fluentbit-based audit sink in the seed's shoot namespace prior to starting the shoot's API server. Therefore, it is required to run this extension with the reconcile lifecycle policy `BeforeKubeAPIServer`. Also the deletion has to happen `BeforeKubeAPIServer` as otherwise the managed resources of this extension block the shoot deletion flow.
 
 This sink has the ability to buffer audit logs to a persistent volume and send them to the supported backends.
 

--- a/example/kustomize/patch-registration.yaml
+++ b/example/kustomize/patch-registration.yaml
@@ -10,5 +10,6 @@ spec:
     type: audit
     globallyEnabled: true
     lifecycle:
+      delete: BeforeKubeAPIServer
+      migrate: BeforeKubeAPIServer
       reconcile: BeforeKubeAPIServer
-      delete: AfterKubeAPIServer


### PR DESCRIPTION
```ACTIONS_REQUIRED
With g/g 1.77, the audit extension's deletion lifecycle policy needs to be changed to `BeforeKubeAPIServer` as otherwise the managed resources of the extension block the shoot deletion flow forever.
``` 