### PR TITLE
Restart audit-webhook-backend StatefulSet on config change

### DIFF
--- a/pkg/controller/audit/actuator.go
+++ b/pkg/controller/audit/actuator.go
@@ -419,13 +419,10 @@ func seedObjects(auditConfig *v1alpha1.AuditConfig, cluster *extensions.Cluster,
 
 		auditwebhookStatefulSet = &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "audit-webhook-backend",
-				Namespace: namespace,
-				Annotations: map[string]string{
-					"checksum/secret-" + auditWebhookConfigSecret.Name: utils.ComputeSecretChecksum(auditWebhookConfigSecret.Data),
-					"checksum/config-" + fluentbitConfigMap.Name:       utils.ComputeConfigMapChecksum(fluentbitConfigMap.Data),
-				},
-				Labels: map[string]string{},
+				Name:        "audit-webhook-backend",
+				Namespace:   namespace,
+				Annotations: map[string]string{},
+				Labels:      map[string]string{},
 			},
 			Spec: appsv1.StatefulSetSpec{
 				Replicas:    getReplicas(cluster, auditConfig.Replicas),
@@ -452,6 +449,8 @@ func seedObjects(auditConfig *v1alpha1.AuditConfig, cluster *extensions.Cluster,
 							"prometheus.io/scrape":                                    "true",
 							"prometheus.io/port":                                      "2020",
 							"prometheus.io/path":                                      "/api/v1/metrics/prometheus",
+							"checksum/secret-" + auditWebhookConfigSecret.Name:        utils.ComputeSecretChecksum(auditWebhookConfigSecret.Data),
+							"checksum/config-" + fluentbitConfigMap.Name:              utils.ComputeConfigMapChecksum(fluentbitConfigMap.Data),
 						},
 					},
 					Spec: corev1.PodSpec{


### PR DESCRIPTION
## Description

During tests I realized that the `audit-webhook-backend` StatefulSet is not getting restarted if the config changes.

In the StatefulSet are already annotations (`statefulset.metadata.annoatations`) with the checksum of the config and secret with the kubeconfig. I assume that they where added to restart the pods, but they are at the wrong place. I moved them to `statefulset.spec.template.metadata.annoatations`.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
