### PR TITLE
Ensure audit-webhook-backend sts restart on changes to backend configuration

### DIFF
--- a/pkg/controller/audit/actuator.go
+++ b/pkg/controller/audit/actuator.go
@@ -450,7 +450,6 @@ func seedObjects(auditConfig *v1alpha1.AuditConfig, cluster *extensions.Cluster,
 							"prometheus.io/port":                                      "2020",
 							"prometheus.io/path":                                      "/api/v1/metrics/prometheus",
 							"checksum/secret-" + auditWebhookConfigSecret.Name:        utils.ComputeSecretChecksum(auditWebhookConfigSecret.Data),
-							"checksum/config-" + fluentbitConfigMap.Name:              utils.ComputeConfigMapChecksum(fluentbitConfigMap.Data),
 						},
 					},
 					Spec: corev1.PodSpec{
@@ -609,6 +608,9 @@ func seedObjects(auditConfig *v1alpha1.AuditConfig, cluster *extensions.Cluster,
 		fluentbitConfigMap.Data[key] = backend.FluentBitConfig(cluster).Generate()
 		backend.PatchAuditWebhook(auditwebhookStatefulSet)
 	}
+
+	// calculate configmap checksum after all backends are applied
+	auditwebhookStatefulSet.Spec.Template.Annotations["checksum/config-"+fluentbitConfigMap.Name] = utils.ComputeConfigMapChecksum(fluentbitConfigMap.Data)
 
 	return objects, nil
 }


### PR DESCRIPTION
We recently encountered a case where a change to the `customData` of the Splunk backend, did not cause a restart of the STS. The underlying reason is that the checksum calculation for the fluentbit configuration currently happens before the backend-specific configuration is applied.

Follow-up fix for https://github.com/metal-stack/gardener-extension-audit/pull/45 .