### PR TITLE
change shoot-namespace to kube-system

### DIFF
--- a/pkg/apis/audit/v1alpha1/types.go
+++ b/pkg/apis/audit/v1alpha1/types.go
@@ -9,7 +9,7 @@ const (
 	SeedAuditResourceName  = "extension-audit"
 	ShootAuditResourceName = "extension-audit-shoot"
 
-	ShootAudittailerNamespace = "audit"
+	ShootAudittailerNamespace = "kube-system"
 
 	AuditWebhookModeBatch          AuditWebhookMode = "batch"
 	AuditWebhookModeBlocking       AuditWebhookMode = "blocking"

--- a/pkg/controller/audit/backend/clusterforwarding.go
+++ b/pkg/controller/audit/backend/clusterforwarding.go
@@ -150,14 +150,6 @@ func (c ClusterForwarding) AdditionalShootObjects(*extensions.Cluster) []client.
 	audittailerServerSecret.ObjectMeta.ResourceVersion = ""
 
 	return []client.Object{
-		&corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: v1alpha1.ShootAudittailerNamespace,
-				Labels: map[string]string{
-					"app": "audittailer",
-				},
-			},
-		},
 		audittailerServerSecret,
 		audittailerConfig,
 		&appsv1.Deployment{


### PR DESCRIPTION
## Description

Closes #24.

## Breaking Changes

```BREAKING_CHANGE
The `audittailer` pod is now being deployed into the `kube-system` namespace and not anymore into the dedicated `audit` namespace.
``` 

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
