### PR TITLE
Update fluentbit and enable tls.verify_hostname for splunk

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -6,7 +6,7 @@ images:
 - name: fluent-bit
   sourceRepository: https://github.com/fluent/fluent-bit
   repository: fluent/fluent-bit
-  tag: "2.1.10"
+  tag: "4.0.5"
 - name: audittailer
   sourceRepository: https://github.com/fluent/fluentd
   repository: fluent/fluentd

--- a/pkg/controller/audit/backend/splunk.go
+++ b/pkg/controller/audit/backend/splunk.go
@@ -87,6 +87,7 @@ func (s Splunk) FluentBitConfig(cluster *extensions.Cluster) fluentbitconfig.Con
 	if s.backend.TlsEnabled {
 		splunkConfig["tls"] = "on"
 		splunkConfig["tls.verify"] = "on"
+		splunkConfig["tls.verify_hostname"] = "on"
 		if s.backend.TlsHost != "" {
 			splunkConfig["tls.vhost"] = s.backend.TlsHost
 		}


### PR DESCRIPTION
## Description

Fluent-bit 2.1.10 is completely out of date. Update to the latest fluentbit version. As far as I'm aware there's not relevant breaking change. [Fluentbit 3.1.0](https://fluentbit.io/announcements/v3.1.0/) has added support for TLS hostname verification (`tls.verify_hostname`) which is off by default. As that makes TLS rather pointless, enable it by default. If you want, I can also make this configurable, but would propose to at least enable it by default.

## Release Notes

### Breaking Change

```BREAKING_CHANGE
In the audit extension, the splunk backend now validates the TLS hostname. Verify that your splunk backend uses a TLS certificate that matches the hostname.
```

(I'm not entirely sure what's the correct classification of that change. Strictly speaking it is a breaking change, but I don't expect it to affect many users)