### PR TITLE
Set sources in `Chart.yaml`

### DIFF
--- a/charts/gardener-extension-audit/Chart.yaml
+++ b/charts/gardener-extension-audit/Chart.yaml
@@ -3,3 +3,5 @@ appVersion: "1.0"
 description: A Helm chart for the audit extension
 name: gardener-extension-audit
 version: 0.1.0
+sources:
+  - https://github.com/metal-stack/gardener-extension-audit


### PR DESCRIPTION
## Description

Adds sources to the Chart manifest. With that, the released OCI helm chart will contain the correct annotations, so that tools like renovate can discover changelogs.

(similar change in g/g: https://github.com/gardener/gardener/pull/12771 )