### PR TITLE
Bump fluentbit version

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -6,7 +6,7 @@ images:
 - name: fluent-bit
   sourceRepository: https://github.com/fluent/fluent-bit
   repository: fluent/fluent-bit
-  tag: "4.0.5"
+  tag: "4.0.12"
 - name: audittailer
   sourceRepository: https://github.com/fluent/fluentd
   repository: fluent/fluentd


### PR DESCRIPTION
## Description

Use latest 4.0 fluent bit version. From what I can tell nothing particularly noteworthy has changed, except maybe the `fluentbit_output_latency_seconds_bucket` metric added in 4.0.6.

@maintainers: Do you have some e.g. renovate instance that could be used to automate bumping the dependency?