### PR TITLE
Enable storage metrics

### DIFF
--- a/pkg/controller/audit/actuator.go
+++ b/pkg/controller/audit/actuator.go
@@ -389,6 +389,7 @@ func seedObjects(auditConfig *v1alpha1.AuditConfig, cluster *extensions.Cluster,
 						"storage.checksum":          "off",
 						"storage.max_chunks_up":     "128",
 						"storage.backlog.mem_limit": "5M",
+						"storage.metrics":           "on",
 
 						"scheduler.base": "1",
 						"scheduler.cap":  "60", // try to send records every 60s


### PR DESCRIPTION
## Description

Enable storage metrics in fluentbit to allow alerting if audit logs pile up. The storage metrics are only available via the v2 metrics endpoint. (see https://docs.fluentbit.io/manual/4.0/administration/monitoring#v2-metrics ). Judging from the fluent-bit docs those metrics became available in fluenbit v2.2. 

The only partially relevant change for prometheus in the metrics that I could find is that the metric `process_start_time_seconds` is now called `fluentbit_process_start_time_seconds`. Not sure whether that falls into the "noteworthy" or "breaking change" category.

## Release Notes

### Noteworthy

```NOTEWORTHY
The audit extension now scrapes the fluentbit v2 metrics, which are a superset of the v1 metrics, and also provides metrics for the storage use. Metric `process_start_time_seconds` is now called `fluentbit_process_start_time_seconds`.
```