### PR TITLE
Helm chart: add missing securityContext to comply with restricted PSS…

### DIFF
--- a/charts/gardener-extension-audit/templates/deployment.yaml
+++ b/charts/gardener-extension-audit/templates/deployment.yaml
@@ -74,6 +74,10 @@ spec:
         resources:
 {{ toYaml .Values.resources | nindent 10 }}
 {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
         volumeMounts:
         - name: config
           mountPath: /etc/{{ include "name" . }}/config
@@ -82,6 +86,10 @@ spec:
           mountPath: /charts_overwrite/
           readOnly: true
         {{- end }}
+      securityContext:
+        runAsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532
       serviceAccountName: {{ include "name" . }}
       # affinity:
       #   podAntiAffinity:

--- a/charts/gardener-extension-audit/values.yaml
+++ b/charts/gardener-extension-audit/values.yaml
@@ -32,7 +32,7 @@ disableWebhooks: []
 #   ...
 
 webhookConfig:
-  serverPort: 443
+  serverPort: 10443
 
 config:
   clientConnection:


### PR DESCRIPTION
… & move pod to serverPort 10443

## Description
Add missing securityContext controls in order to comply with the [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) Pod Security Standards policy.

In addition move the default serverPort to 10443 because ports < 1024 are privileged.

Related to https://github.com/gardener/gardener/issues/12658

### Noteworthy

```NOTEWORTHY
Add missing securityContext controls in order to comply with the restricted Pod Security Standards policy. Move default serverPort to 10443.
```
