### PR TITLE
Revert fluentbit upgrade to 4.0.12 to fix rare OOM crashes

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -6,7 +6,7 @@ images:
 - name: fluent-bit
   sourceRepository: https://github.com/fluent/fluent-bit
   repository: fluent/fluent-bit
-  tag: "4.0.12"
+  tag: "4.0.5"
 - name: audittailer
   sourceRepository: https://github.com/fluent/fluentd
   repository: fluent/fluentd


### PR DESCRIPTION
## Description

The update of fluentbit from 4.0.5 to 4.0.12 has introduce some rare OOM kills. We see a few of those OOM kills of fluentbit now every day. Fluentbit shows normal memory usage until it suddenly runs out of memory. This coincides with log entries like the following:

```
[ warn] [msgpack2json] unknown msgpack type -45509955
```

Bumping fluentbit all the way to 4.1.1 did not resolve the issue. So the only option is to downgrade it again (we've already verified that this downgrade fixes the OOM kills). I've already opened an issue upsteam: https://github.com/fluent/fluent-bit/issues/11078 .

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
## Release Notes

### Noteworthy

```NOTEWORTHY
The fluentbit version used by the audit extension has been downgraded to 4.0.5 to fix rare OOM kills of fluentbit.
```